### PR TITLE
Prevent deletion of counterpart_lines

### DIFF
--- a/statement.py
+++ b/statement.py
@@ -112,6 +112,8 @@ class StatementLine(metaclass=PoolMeta):
         check_lines = dict((c, set()) for c in company_ids)
 
         for line in lines:
+            if not line.account_date:
+                continue
             check_lines.setdefault(line.company.id, set()).add(line.account_date)
 
         for company, dates in check_lines.items():

--- a/statement.py
+++ b/statement.py
@@ -137,7 +137,10 @@ class StatementLine(metaclass=PoolMeta):
         cls.reset_counterpart_move(statement_lines)
         to_write = []
         for st_line in statement_lines:
-            st_line.counterpart_lines = None
+            st_line._fields['counterpart_lines'].remove(
+                st_line,
+                st_line.counterpart_lines
+            )
             to_write.extend(([st_line], st_line._save_values))
         if to_write:
             cls.write(*to_write)

--- a/tryton.cfg
+++ b/tryton.cfg
@@ -1,5 +1,5 @@
 [tryton]
-version=6.1.0
+version=6.0.0
 depends:
     ir
     account_bank_statement

--- a/tryton.cfg
+++ b/tryton.cfg
@@ -1,5 +1,5 @@
 [tryton]
-version=5.9.0
+version=6.1.0
 depends:
     ir
     account_bank_statement


### PR DESCRIPTION
Prevent deletion of counterpart_lines since 5.6 tries to delete records in a One2Many relation instead of unlink them.